### PR TITLE
Minor Fix - Final Batch Size if Total Samples to use in FID Calculation is a multiple of Batch Size

### DIFF
--- a/ddpm_torch/metrics/__init__.py
+++ b/ddpm_torch/metrics/__init__.py
@@ -40,7 +40,7 @@ class Evaluator:
         with trange(num_batches, desc="Evaluating FID", disable=not is_leader) as t:
             for i in t:
                 if i == len(t) - 1:
-                    batch_size = self.eval_total_size % self.eval_batch_size
+                    batch_size = (self.eval_total_size % self.eval_batch_size) or self.eval_batch_size
                 else:
                     batch_size = self.eval_batch_size
                 x = sample_fn(sample_size=batch_size, diffusion=self.diffusion)


### PR DESCRIPTION
Thank you so much for open sourcing this work! I think I may have found a very, very slight issue. 

When using the `--eval-total-size` argument, the final batch in the evaluator will be `0` if the value passed to `--eval-total-size` is a multiple of the batch size, i.e. `self.eval_total_size % self.eval_batch_size = 0`. 

```
python train.py --eval --eval-total-size 512
```

This will cause a `ValueError` later in the FID calculation since we compute the mean of an empty array. 